### PR TITLE
🐛(circleci) fix PyPI upload step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -99,6 +99,11 @@ jobs:
           keys:
             - v1-distributions-{{ checksum "setup.cfg" }}
 
+      # Restore python virtualenv
+      - restore_cache:
+          keys:
+            - v1-dependencies-{{ checksum "setup.cfg" }}
+
       - run:
           name: Publish distributions to PyPI
           command: |
@@ -106,6 +111,7 @@ jobs:
             ls dist/*
 
             echo ":::: Publish distributions ::::"
+            . venv/bin/activate
             twine upload dist/*
 
 # CI workflows


### PR DESCRIPTION
## Purpose

Twine is not available in the CI's  PyPI upload step.

## Proposal

Twine is installed in a python virtual environment (venv) in the build step, hence, we need to restore cached venv before trying to use it.