### PR TITLE
🔧(settings) configure session engine

### DIFF
--- a/config/cms/docker_run_development.py
+++ b/config/cms/docker_run_development.py
@@ -18,3 +18,5 @@ PIPELINE_ENABLED = False
 STATICFILES_STORAGE = "openedx.core.storage.DevelopmentStorage"
 
 ALLOWED_HOSTS = ["*"]
+
+SESSION_ENGINE = "django.contrib.sessions.backends.cached_db"

--- a/config/lms/docker_run_development.py
+++ b/config/lms/docker_run_development.py
@@ -20,3 +20,5 @@ STATICFILES_STORAGE = "openedx.core.storage.DevelopmentStorage"
 ALLOWED_HOSTS = ["*"]
 
 WEBPACK_CONFIG_PATH = "webpack.dev.config.js"
+
+SESSION_ENGINE = "django.contrib.sessions.backends.cached_db"


### PR DESCRIPTION
Persistant sessions between server restarts is mandatory in
development environment