### PR TITLE
Fix django settings circular import

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,11 @@ RUN pip install --no-cache-dir --src /usr/local/src -e /edx/app/xblock
 # FIXME: as mentionned in fun-platform and edx-platform bug tracker, this
 # webpack-stats.json is required both in production and development in a static
 # directory 😢
+#
+# Also, the /edx/var tree should be writable by the running user to perform
+# collectstatic and migrations.
 RUN mkdir -p /edx/app/edxapp/staticfiles/studio && \
+    chown -R edx:edx /edx/var && \
     cp /edx/app/edxapp/edx-platform/common/static/webpack-stats.json /edx/app/edxapp/staticfiles/ && \
     cp /edx/app/edxapp/edx-platform/common/static/studio/webpack-stats.json /edx/app/edxapp/staticfiles/studio/
 

--- a/configurable_lti_consumer/configurable_lti_consumer.py
+++ b/configurable_lti_consumer/configurable_lti_consumer.py
@@ -1,9 +1,8 @@
 from django.conf import settings
-
 from lti_consumer import LtiConsumerXBlock
 
+from .defaults import DEFAULT_CONFIGURABLE_LTI_CONSUMER_SETTINGS
 from .exceptions import ConfigurableLTIConsumerException
-from .defaults import CONFIGURABLE_LTI_CONSUMER_SETTINGS
 
 
 class ConfigurableLtiConsumerXBlock(LtiConsumerXBlock):
@@ -38,7 +37,11 @@ class ConfigurableLtiConsumerXBlock(LtiConsumerXBlock):
         Retrieving component subclass configuration from Django settings
         """
 
-        for conf_name, configuration in CONFIGURABLE_LTI_CONSUMER_SETTINGS.items():
+        for conf_name, configuration in getattr(
+            settings,
+            "CONFIGURABLE_LTI_CONSUMER_SETTINGS",
+            DEFAULT_CONFIGURABLE_LTI_CONSUMER_SETTINGS,
+        ).items():
             if conf_name == name:
                 return configuration
         else:

--- a/configurable_lti_consumer/defaults.py
+++ b/configurable_lti_consumer/defaults.py
@@ -1,6 +1,4 @@
 """Default settings for Configurable LTI Consumer"""
-from django.conf import settings
-
 
 # configurable-lti-consumer sample configuration
 DEFAULT_CONFIGURABLE_LTI_CONSUMER_SETTINGS = {
@@ -36,10 +34,3 @@ DEFAULT_CONFIGURABLE_LTI_CONSUMER_SETTINGS = {
         },
     },
 }
-
-
-CONFIGURABLE_LTI_CONSUMER_SETTINGS = getattr(
-    settings,
-    "CONFIGURABLE_LTI_CONSUMER_SETTINGS",
-    DEFAULT_CONFIGURABLE_LTI_CONSUMER_SETTINGS,
-)

--- a/configurable_lti_consumer/defaults.py
+++ b/configurable_lti_consumer/defaults.py
@@ -24,21 +24,22 @@ DEFAULT_CONFIGURABLE_LTI_CONSUMER_SETTINGS = {
             "hide_launch": False,
             "accept_grades_past_due": False,
             "ask_to_send_username": True,
-            "ask_to_send_email": True
-            }
+            "ask_to_send_email": True,
+        },
     },
     "Generic": {
         "display": "Generic LTI xblock",
         "default_values": {
             "lti_id": "Generic",
             "ask_to_send_username": True,
-            "ask_to_send_email": True
-        }
-    }
+            "ask_to_send_email": True,
+        },
+    },
 }
 
 
-
 CONFIGURABLE_LTI_CONSUMER_SETTINGS = getattr(
-    settings, "CONFIGURABLE_LTI_CONSUMER_SETTINGS", DEFAULT_CONFIGURABLE_LTI_CONSUMER_SETTINGS
+    settings,
+    "CONFIGURABLE_LTI_CONSUMER_SETTINGS",
+    DEFAULT_CONFIGURABLE_LTI_CONSUMER_SETTINGS,
 )

--- a/configurable_lti_consumer/utils.py
+++ b/configurable_lti_consumer/utils.py
@@ -3,8 +3,6 @@
 Helper fonctions
 """
 
-from django.conf import settings
-
 
 def add_dynamic_components(
     CONFIGURABLE_LTI_CONSUMER_SETTINGS,


### PR DESCRIPTION
## Purpose

The `defaults.py` pattern used in this repository implies loading Django settings, but, we also need to import the `filter_configurable_lti_consumer` in Django settings. As Xblocks force us to import XBlock from the module's root, we had a circular importation issue with Django settings.

## Proposal

As suggested by @sampaccoud, we now set default configuration at runtime if it has not been defined in the project's settings.

We've also fixed docker-related issues to make the repository more reliable. Sorry for this out-of-scope work :pray:.