### PR TITLE
🐛(entrypoint) make sure xblock entrypoint is used in development

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,8 +25,9 @@ RUN mkdir /edx/var && \
 # Copy the app to the working directory
 COPY --chown=edx:edx . /edx/app/xblock/
 
-# Install development dependencies in a virtualenv
-RUN pip install --no-cache-dir --src /usr/local/src -e /edx/app/xblock
+# Install development dependencies and perform a base installation of the xblock
+RUN cd /edx/app/xblock/ && \
+    pip install --no-cache-dir .
 
 # FIXME: as mentionned in fun-platform and edx-platform bug tracker, this
 # webpack-stats.json is required both in production and development in a static

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,7 +34,9 @@ services:
     ports:
       - "8072:8000"
     volumes:
-      - .:/edx/app/xblock
+      # Override installed xblock with the xblock source directory to provide an
+      # editable environment
+      - ./configurable_lti_consumer:/usr/local/lib/python2.7/dist-packages/configurable_lti_consumer
       - ./config/lms/docker_run_development.py:/config/lms/docker_run_development.py
       - ./data/media:/edx/var/edxapp/media
       - ./data/store:/edx/app/edxapp/data


### PR DESCRIPTION
# Purpose

Installing the Xblock in editable mode with pip does not properly handle entrypoints and mixes our entrypoint with the original one from the `lti_consumer-xblock`.

## Proposal

This can be fixed by installing our Xblock in non-editable mode and mounting the project's _ad hoc_ directory where it is expected in python's distribution local packages. Thank you Docker ❤