### PR TITLE
🔖(patch) bump release to 1.0.0-rc2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,28 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic
+Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [1.0.0-rc2] - 2019-01-15
+
+### Added
+
+- Add iframeResizer to automatically fit the height of the LTI iframe to its content.
+
+### Fixed
+
+- Remove header on top of the LTI window as it seems useless. We want to let the LTI service
+  control the totality of the content displayed by the XBlock.
+
+## [1.0.0-rc1] - 2018-11-28
+
+This is a first release candidate for production.
+
+[unreleased]: https://github.com/openfun/xblock-configurable-lti-consumer/compare/v1.0.0-rc2...master
+[1.0.0-rc2]: https://github.com/openfun/xblock-configurable-lti-consumer/compare/v1.0.0-rc1...v1.0.0-rc2
+[1.0.0-rc1]: https://github.com/openfun/xblock-configurable-lti-consumer/compare/v0.2.1...v1.0.0-rc1

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,7 @@
 ;;
 [metadata]
 name = configurable_lti_consumer-xblock
-version = 1.0.0-rc.1
+version = 1.0.0-rc.2
 description = This Xblock adds configurability over the original lti_consumer XBlock from edx
 long_description = file: README.md
 long_description_content_type = text/markdown


### PR DESCRIPTION
Added

- Add iframeResizer to automatically fit the height of the LTI iframe to its content.

Fixed

- Remove header on top of the LTI window as it seems useless. We want to let the LTI service control the totality of the content displayed by the XBlock.