### PR TITLE
🐛(circleci) fix pypi distribution cache key

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,7 +55,7 @@ jobs:
       - save_cache:
           paths:
             - ./dist
-          key: v1-distributions-{{ checksum "setup.cfg" }}
+          key: v1-distributions-{{ .Revision }}
 
   # Check that target git tag refers to a master branch commit and matches the
   # "version" from setup.cfg
@@ -97,7 +97,7 @@ jobs:
       # Restore built packages
       - restore_cache:
           keys:
-            - v1-distributions-{{ checksum "setup.cfg" }}
+            - v1-distributions-{{ .Revision }}
 
       # Restore python virtualenv
       - restore_cache:


### PR DESCRIPTION
## Purpose

The pypi packages were saved to cache using the checksum of the setup.cfg file as a key. This lead circleci to push the wrong package on our release 1.0.0-rc.2 because the PR to bump the version number was prepared before merging everything that we wanted to add to this PR. The release commit was then rebased on master but it was too late, the cache in circleCI was already set with an incomplete tar.gz.

## Proposal

Using the commit hash as cache key for distribution packages ensures that it will vary each time the code varies.
