### PR TITLE
✨(configuration) allow defining dynamic launch urls

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ LTI_XBLOCK_CONFIGURATIONS = [
         "display_name": "Marsha Video",
         "oauth_consumer_key": "InsecureOauthConsumerKey",
         "shared_secret": "InsecureSharedSecret",
+        "is_launch_url_regex": True,
         "hidden_fields": [
             "lti_id",
             "description",
@@ -93,7 +94,7 @@ LTI_XBLOCK_CONFIGURATIONS = [
             "hide_launch": False,
             "launch_target": "iframe",
             "modal_width": 80,
-            "launch_url": "https://marsha.education/lti-video/",
+            "launch_url": "https://marsha\.education/lti/videos/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}",
             "lti_id": "marsha",
         },
     },

--- a/config/settings.yml.dist
+++ b/config/settings.yml.dist
@@ -3,10 +3,11 @@ LTI_XBLOCK_CONFIGURATIONS:
   - display_name: Marsha Video
     oauth_consumer_key: InsecureOauthConsumerKey
     shared_secret: InsecureSharedSecret
+    is_launch_url_regex: true
     defaults:
       lti_id: marsha
       launch_target: iframe
-      launch_url: https://marsha.education/lti-video/
+      launch_url: https://marsha\.education/lti/videos/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}
       custom_parameters: []
       button_text: button
       modal_height: 400

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,6 +28,7 @@ dependency_links =
 include_package_data = true
 install_requires =
     lti_consumer-xblock>=1.1.8
+    exrex==0.10.5
 packages = configurable_lti_consumer
 zip_safe = False
 


### PR DESCRIPTION
### Purpose

In some cases the LTI service we are calling requires a unique launch url for each XBlock calling the service. Indeed, the LTI specification requires that the XBlock be identified by its url, not by its resource_link_id.

### Proposal

We use exrex to generate a random launch url respecting a regex. This can for example be used to generate launch urls of the form:

`https://marsha.education/lti-video/d8edd6fb-09e2-405d-e2e2-6f41734eac85`

by defining the following regex:
```regex
https://marsha.education/lti-video/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}
```