### PR TITLE
⚡️(iframe) precalculate iframe height to improve user visual feeling

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,8 @@ LTI_XBLOCK_CONFIGURATIONS = [
         "oauth_consumer_key": "InsecureOauthConsumerKey",
         "shared_secret": "InsecureSharedSecret",
         "is_launch_url_regex": True,
+        "automatic_resizing": True,
+        "inline_ratio": 0.5625,
         "hidden_fields": [
             "lti_id",
             "description",
@@ -99,7 +101,7 @@ LTI_XBLOCK_CONFIGURATIONS = [
         },
     },
     {
-        "pattern": ".*ltiapps\\.net.*",
+        "pattern": ".*ltiapps\.net.*",
         "hidden_fields": ["launch_target"],
         "defaults": {"launch_target": "modal"},
     },
@@ -107,6 +109,7 @@ LTI_XBLOCK_CONFIGURATIONS = [
         "display_name": "LTI consumer",
         "pattern": ".*",
         "hidden_fields": ["ask_to_send_username", "ask_to_send_email"],
+        "automatic_resizing": False,
         "defaults": {
             "ask_to_send_email": True,
             "launch_target": "new_window",

--- a/config/settings.yml.dist
+++ b/config/settings.yml.dist
@@ -4,6 +4,8 @@ LTI_XBLOCK_CONFIGURATIONS:
     oauth_consumer_key: InsecureOauthConsumerKey
     shared_secret: InsecureSharedSecret
     is_launch_url_regex: true
+    automatic_resizing: true
+    inline_ratio: 0.5625 # 16/9
     defaults:
       lti_id: marsha
       launch_target: iframe

--- a/configurable_lti_consumer/static/js/configurable_xblock_lti_consumer.js
+++ b/configurable_lti_consumer/static/js/configurable_xblock_lti_consumer.js
@@ -1,9 +1,24 @@
-function configurableLTIConsumerXblockIframeResizerInit() {
-    $(function ($) {
-        LtiConsumerXBlock();  // call inherited lti_consumer javascript initialization
-        $('.ltiLaunchFrame').iFrameResize({ // Initialize IframeResizer on lti_consumer iframe class
+function configurableLTIConsumerXblockIframeResizerInit(runtime, element, json_args) {
+    var $element = $("#" + json_args["element_id"]);
+    LtiConsumerXBlock();  // call inherited lti_consumer javascript initialization
+    var $iframe = $element.find('iframe');
+    var $div = $element.find("div");
+    var automatic_resizing = $div.data('automatic-resizing') === "True"?true:false;
+    var inline_ratio = parseFloat($div.data('inline-ratio')) || false;
+    var inline_height = parseFloat($div.data('inline-height')) || false;
+    var width = $('.content-primary,.vert-mod').width();
+
+    if (automatic_resizing) {
+        $iframe.iFrameResize({ // Initialize IframeResizer on lti_consumer iframe
             checkOrigin: false,
             log: false
-        })
-    });
+        });
+    }
+    if (inline_ratio) {
+        var estimated_height = width * inline_ratio;
+        $iframe.height(estimated_height);
+    } else if (inline_height) {
+        $iframe.height(inline_height);
+    }
 };
+

--- a/configurable_lti_consumer/templates/html/student.html
+++ b/configurable_lti_consumer/templates/html/student.html
@@ -63,14 +63,12 @@
         </section>
     % endif
     % if launch_target == 'iframe':
-        % if inline_height:
-            <div style="height: ${inline_height}px;">
-        % else:
-            ## iframeResizer will automaticaly set iframe height
-            <div>
-        % endif
-            ## The result of the LTI launch form submit will be rendered here.
-            <%include file="templates/html/lti_iframe.html" args="initial_launch_url=form_url"/>
+        <div data-automatic-resizing="${automatic_resizing}"
+             data-inline-ratio="${inline_ratio}"
+             data-inline-height="${inline_height}">
+
+        ## The result of the LTI launch form submit will be rendered here.
+        <%include file="templates/html/lti_iframe.html" args="initial_launch_url=form_url"/>
         </div>
     % endif
 % elif not hide_launch:


### PR DESCRIPTION
As iframeResizer may take a few seconds to initialize and set correct iframe
height, we calculate probable height regarding available width and configuration
given ratio. We also use more comprehensive settings and drop deprecated
XBlock.fragment library in favor of web_fragment.fragment
