### PR TITLE
Small ux improvements

### DIFF
--- a/configurable_lti_consumer/configurable_lti_consumer.py
+++ b/configurable_lti_consumer/configurable_lti_consumer.py
@@ -124,14 +124,19 @@ class ConfigurableLtiConsumerXBlock(LtiConsumerXBlock):
     def lti_provider_key_secret(self):
         """
         Override parent's method to use credentials from Django settings if
-        available instead of courses settings
+        available if no credentials are declared in the course.
         """
-        configuration = self.get_configuration(self.launch_url)
-        if configuration.get("oauth_consumer_key") and configuration.get(
-            "shared_secret"
-        ):
-            return (configuration["oauth_consumer_key"], configuration["shared_secret"])
-        return super(ConfigurableLtiConsumerXBlock, self).lti_provider_key_secret
+        key, secret = super(ConfigurableLtiConsumerXBlock, self).lti_provider_key_secret
+
+        if not (key and secret):
+            configuration = self.get_configuration(self.launch_url)
+            if configuration.get("oauth_consumer_key") and configuration.get(
+                "shared_secret"
+            ):
+                key = configuration["oauth_consumer_key"]
+                secret = configuration["shared_secret"]
+
+        return key, secret
 
     def student_view(self, context):
         """

--- a/configurable_lti_consumer/configurable_lti_consumer.py
+++ b/configurable_lti_consumer/configurable_lti_consumer.py
@@ -64,17 +64,16 @@ class ConfigurableLtiConsumerXBlock(LtiConsumerXBlock):
 
     def __getattribute__(self, item):
         """
-        First look for the value of a field in our XBlock settings and default to the normal
-        behavior which is to retrieve the value stored in Mongodb.
+        First look for the value of a field in our XBlock settings (only for fields that have a
+        default AND are hidden) and default to the normal behavior which is to retrieve the value
+        stored in Mongodb.
         """
         # We always need to get the `launch_url` from Mongodb because it is used to associate the
         # XBlock with a configuration.
         if item != "launch_url" and item in LtiConsumerXBlock.editable_field_names:
-            # Better ask for forgiveness than ask for permission...
-            try:
-                return self.get_configuration(self.launch_url)["defaults"][item]
-            except KeyError:
-                pass
+            configuration = self.get_configuration(self.launch_url)
+            if item in configuration["defaults"] and item in configuration['hidden_fields']:
+                return configuration["defaults"][item]
         return super(ConfigurableLtiConsumerXBlock, self).__getattribute__(item)
 
     @classmethod


### PR DESCRIPTION
### Purpose

After a few weeks using this configurable XBlock in production, we identified 2 small inconveniencies:

- when a field is not hidden, the user can modify its value but it has no effect on the XBlock because field values are read from the settings only,
- when a user defines a passport in the course, it is ignored because our XBlock gives precedence to the passport defined in our settings.

### Proposal

- [x] Use field values from Mongodb for fields that are visible, and field values from our settings for fields that are hidden.
- [x] Give precedence to a passport defined in the course (with the same `lti_id`) over the passport defined in our settings (Fixes https://github.com/openfun/xblock-configurable-lti-consumer/issues/26),

