### PR TITLE
🐛(package) fix deprecated pip option

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,7 @@ jobs:
           command: |
             virtualenv venv
             . venv/bin/activate
-            pip install --process-dependency-links  -e .[dev]
+            pip install -e .[dev]
 
       # Cache virtual environment
       - save_cache:

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,11 +23,9 @@ classifiers =
     Programming Language :: Python :: 2.7
 
 [options]
-dependency_links =
-    https://github.com/edx/xblock-lti-consumer/tarball/v1.1.8#egg=lti_consumer-xblock-1.1.8
 include_package_data = true
 install_requires =
-    lti_consumer-xblock>=1.1.8
+    lti_consumer-xblock @ git+https://github.com/edx/xblock-lti-consumer@v1.1.8#egg=lti_consumer-xblock-1.1.8
     exrex==0.10.5
 packages = configurable_lti_consumer
 zip_safe = False


### PR DESCRIPTION
## Purpose

The `--process-dependency-links` option for the `pip install` command has been deprecated.

## Proposal

- [x] switch to the PEP 508 URL requirement format 

NB: PEP 508 has been implemented since the 18.1 pip release, hence `pip>=18.1` is now required.