### PR TITLE
Fix unpublishable package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.2.1] - 2019-02-14
+
+### Fixed
+
+- Remove edX LTI consumer Xblock as a dependency as Pypi does not allow
+  publishing a package with dependencies listed as PEP 508 URLs.
+
 ## [1.2.0] - 2019-02-13
 
 ### Added
@@ -57,7 +64,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 This is a first release candidate for production.
 
-[unreleased]: https://github.com/openfun/xblock-configurable-lti-consumer/compare/v1.2.0...master
+[unreleased]: https://github.com/openfun/xblock-configurable-lti-consumer/compare/v1.2.1...master
+[1.2.1]: https://github.com/openfun/xblock-configurable-lti-consumer/compare/v1.2.0...v1.2.1
 [1.2.0]: https://github.com/openfun/xblock-configurable-lti-consumer/compare/v1.1.0...v1.2.0
 [1.1.0]: https://github.com/openfun/xblock-configurable-lti-consumer/compare/v1.0.0-rc.4...v1.1.0
 [1.0.0-rc.4]: https://github.com/openfun/xblock-configurable-lti-consumer/compare/v1.0.0-rc.3...v1.0.0-rc.4

--- a/README.md
+++ b/README.md
@@ -20,10 +20,16 @@ This package can be installed with `pip`:
 $ pip install configurable_lti_consumer-xblock
 ```
 
-> `pip>=1.8.1` is required to process package dependencies if you are willing to
-> install or test this XBlock as a standalone package. If you plan to install it
-> in a base Open edX installation, then you can safely use an older `pip`
-> release.
+Edx's [lti_consumer-xblock](https://github.com/edx/xblock-lti-consumer) is
+required as an extra dependency if you are willing to install or test this
+XBlock as a standalone package. You can install it separately with `pip`:
+
+```bash
+$ pip install git+https://github.com/edx/xblock-lti-consumer@v1.1.8#egg=lti-consumer-xblock
+```
+
+If you plan to install it in a base Open edX installation, this dependency will
+already be available, and thus you don't need to execute the above command.
 
 ## Getting started
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,7 +25,6 @@ classifiers =
 [options]
 include_package_data = true
 install_requires =
-    lti_consumer-xblock @ git+https://github.com/edx/xblock-lti-consumer@v1.1.8#egg=lti_consumer-xblock-1.1.8
     exrex==0.10.5
 packages = configurable_lti_consumer
 zip_safe = False
@@ -45,7 +44,7 @@ configurable_lti_consumer =
     static/js/*.js
     static/js/vendor/*.js
 
-[wheel]
+[bdist_wheel]
 universal = 1
 
 [pep8]

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,7 @@
 ;;
 [metadata]
 name = configurable_lti_consumer-xblock
-version = 1.2.0
+version = 1.2.1
 description = This Xblock adds configurability over the original lti_consumer XBlock from edx
 long_description = file: README.md
 long_description_content_type = text/markdown


### PR DESCRIPTION
## Purpose

PyPI forbids uploading a package that has PEP 508 URLs in its requirements, making impossible to publish a new package release.

## Proposal

- [x] remove [edX LTI consumer Xblock](https://github.com/edx/xblock-lti-consumer) dependency
- [x] bump release to `1.2.1`