### PR TITLE
Split secrets and settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,19 @@ This configuration does several things:
 The order of each configuration in this list is important because we will use, for a given
 XBlock, the first configuration pattern that matches its launch url.
 
+If you wish to encrypt the `oauth_consumer_key` and `shared_secret` credentials and keep the
+other settings visible, you can declare one of them or both in a separate setting
+`LTI_XBLOCK_CONFIGURATIONS`, using the `lti_id` as mapping key:
+
+```python
+LTI_XBLOCK_CONFIGURATIONS = {
+    "marsha": {
+        "oauth_consumer_key": "InsecureOauthConsumerKey",
+        "shared_secret": "InsecureSharedSecret",
+    }
+}
+```
+
 Note that the workbench included in the present repository is running this configuration
 (see [config/settings.yml.dist](./config/settings.yml.dist)) on the official France Université Numérique
 [Open edX extended Docker image](https://github.com/openfun/openedx-docker).

--- a/config/cms/docker_run_development.py
+++ b/config/cms/docker_run_development.py
@@ -26,3 +26,6 @@ SESSION_ENGINE = "django.contrib.sessions.backends.cached_db"
 LTI_XBLOCK_CONFIGURATIONS = config(
     "LTI_XBLOCK_CONFIGURATIONS", default=[], formatter=json.loads
 )
+LTI_XBLOCK_SECRETS = config(
+    "LTI_XBLOCK_SECRETS", default={}, formatter=json.loads
+)

--- a/config/lms/docker_run_development.py
+++ b/config/lms/docker_run_development.py
@@ -28,3 +28,6 @@ SESSION_ENGINE = "django.contrib.sessions.backends.cached_db"
 LTI_XBLOCK_CONFIGURATIONS = config(
     "LTI_XBLOCK_CONFIGURATIONS", default=[], formatter=json.loads
 )
+LTI_XBLOCK_SECRETS = config(
+    "LTI_XBLOCK_SECRETS", default={}, formatter=json.loads
+)

--- a/config/settings.yml.dist
+++ b/config/settings.yml.dist
@@ -1,8 +1,6 @@
 LTI_XBLOCK_CONFIGURATIONS:
   # A configuration that adds a Marsha Video XBlock
   - display_name: Marsha Video
-    oauth_consumer_key: InsecureOauthConsumerKey
-    shared_secret: InsecureSharedSecret
     is_launch_url_regex: true
     automatic_resizing: true
     inline_ratio: 0.5625 # 16/9
@@ -54,3 +52,8 @@ LTI_XBLOCK_CONFIGURATIONS:
     hidden_fields:
       - ask_to_send_username
       - ask_to_send_email
+
+LTI_XBLOCK_SECRETS:
+  marsha:
+    oauth_consumer_key: InsecureOauthConsumerKey
+    shared_secret: InsecureSharedSecret

--- a/configurable_lti_consumer/configurable_lti_consumer.py
+++ b/configurable_lti_consumer/configurable_lti_consumer.py
@@ -72,7 +72,9 @@ class ConfigurableLtiConsumerXBlock(LtiConsumerXBlock):
         # XBlock with a configuration.
         if item != "launch_url" and item in LtiConsumerXBlock.editable_field_names:
             configuration = self.get_configuration(self.launch_url)
-            if item in configuration["defaults"] and item in configuration['hidden_fields']:
+            if item in configuration.get("defaults", []) and item in configuration.get(
+                "hidden_fields", []
+            ):
                 return configuration["defaults"][item]
         return super(ConfigurableLtiConsumerXBlock, self).__getattribute__(item)
 


### PR DESCRIPTION
### purpose

settings and credentials were all defined in the same configuration object. This forced us to encrypt the whole thing which leads to useless diffs and commit history. Let's separate both types of settings in two separate variables so we can encrypt only what must be secret.

### Proposal

- [x] add a separate secret setting to configure credentials (keep backward compatibility by defaulting to credentials in the main configuration setting as before...)

While working on this I also fixed an unrelated bug:
- [x] don't fail getting `defaults` and `hidden_fields` when they are not defined 

