### PR TITLE
🐛(exceptions) fix missing import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.2.3] - 2019-03-18
+
+### Fixed
+
+- Fix missing exceptions import causing crash in case of misconfiguration
+
 ## [1.2.2] - 2019-03-04
 
 ### Added
@@ -75,7 +81,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 This is a first release candidate for production.
 
-[unreleased]: https://github.com/openfun/xblock-configurable-lti-consumer/compare/v1.2.2...master
+[unreleased]: https://github.com/openfun/xblock-configurable-lti-consumer/compare/v1.2.3...master
+[1.2.3]: https://github.com/openfun/xblock-configurable-lti-consumer/compare/v1.2.2...v1.2.3
 [1.2.2]: https://github.com/openfun/xblock-configurable-lti-consumer/compare/v1.2.1...v1.2.2
 [1.2.1]: https://github.com/openfun/xblock-configurable-lti-consumer/compare/v1.2.0...v1.2.1
 [1.2.0]: https://github.com/openfun/xblock-configurable-lti-consumer/compare/v1.1.0...v1.2.0

--- a/configurable_lti_consumer/configurable_lti_consumer.py
+++ b/configurable_lti_consumer/configurable_lti_consumer.py
@@ -88,7 +88,6 @@ class ConfigurableLtiConsumerXBlock(LtiConsumerXBlock):
         """
         # we need a serializable value to use as our cache key
         launch_url = launch_url or ""
-
         # First, try returning the value direcly from the cache
         try:
             return getattr(cls, "_configuration_cache", {})[launch_url]
@@ -106,7 +105,6 @@ class ConfigurableLtiConsumerXBlock(LtiConsumerXBlock):
             if not pattern:
                 default_url = configuration.get("defaults", {}).get("launch_url", ".*")
                 pattern = r"^{}$".format(default_url)
-
             if re.match(pattern, launch_url):
                 # This configuration is matching, let's use it!
                 break

--- a/configurable_lti_consumer/load_class.py
+++ b/configurable_lti_consumer/load_class.py
@@ -2,6 +2,7 @@
 Helper function that will be passed to the XBlock.load_class method to filter multiple Python
 entry points for the same XBlock (lti_consumer).
 """
+from xblock.plugin import AmbiguousPluginError, PluginMissingError
 from xmodule import modulestore
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,7 @@
 ;;
 [metadata]
 name = configurable_lti_consumer-xblock
-version = 1.2.2
+version = 1.2.3
 description = This Xblock adds configurability over the original lti_consumer XBlock from edx
 long_description = file: README.md
 long_description_content_type = text/markdown


### PR DESCRIPTION
We forgot to import exceptions raised by `load_class` function
causing crash when xblock not installed or wrongly configured