### PR TITLE
📦(eucalyptus) add missing exrex dependency

### DIFF
--- a/.env
+++ b/.env
@@ -1,6 +1,6 @@
 # Django
-SERVICE_VARIANT: lms
-DJANGO_SETTINGS_MODULE: lms.envs.fun.docker_run
+SERVICE_VARIANT=lms
+DJANGO_SETTINGS_MODULE=lms.envs.fun.docker_run
 
 # Database
 MYSQL_ROOT_PASSWORD=

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,12 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
-## 2019-11-15
+## [1.2.5] - 2019-11-15
 
 # Fixed
 
 - Add missing exrex dependency to packaging
+- Typo in docker environment variables
 
 ## [1.2.4] - 2019-04-15
 
@@ -92,7 +93,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 ## [1.0.0-rc.1] - 2018-11-28
 
 This is a first release candidate for production.
-[unreleased]: https://github.com/openfun/xblock-configurable-lti-consumer/compare/v1.2.4...master
+[unreleased]: https://github.com/openfun/xblock-configurable-lti-consumer/compare/v1.2.5...master
+[1.2.5]: https://github.com/openfun/xblock-configurable-lti-consumer/compare/v1.2.4...v1.2.5
 [1.2.4]: https://github.com/openfun/xblock-configurable-lti-consumer/compare/v1.2.3...v1.2.4
 [1.2.3]: https://github.com/openfun/xblock-configurable-lti-consumer/compare/v1.2.2...v1.2.3
 [1.2.2]: https://github.com/openfun/xblock-configurable-lti-consumer/compare/v1.2.1...v1.2.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## 2019-11-15
+
+# Fixed
+
+- Add missing exrex dependency to packaging
 
 ## [1.2.4] - 2019-04-15
 
@@ -87,8 +92,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 ## [1.0.0-rc.1] - 2018-11-28
 
 This is a first release candidate for production.
-
-[unreleased]: https://github.com/openfun/xblock-configurable-lti-consumer/compare/v1.2.3...master
+[unreleased]: https://github.com/openfun/xblock-configurable-lti-consumer/compare/v1.2.4...master
+[1.2.4]: https://github.com/openfun/xblock-configurable-lti-consumer/compare/v1.2.3...v1.2.4
 [1.2.3]: https://github.com/openfun/xblock-configurable-lti-consumer/compare/v1.2.2...v1.2.3
 [1.2.2]: https://github.com/openfun/xblock-configurable-lti-consumer/compare/v1.2.1...v1.2.2
 [1.2.1]: https://github.com/openfun/xblock-configurable-lti-consumer/compare/v1.2.0...v1.2.1

--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,7 @@ setup(name="xblock-configurable-lti-consumer",
       ],
     install_requires=[
         "XBlock",
+        "exrex==0.10.5",
     ],
     entry_points={
         "xblock.v1": [

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ def package_data(pkg, roots):
 
 
 setup(name="xblock-configurable-lti-consumer",
-      version="1.2.4+eucalyptus",
+      version="1.2.5+eucalyptus",
       description="This Xblock adds configurability over the original lti_consumer XBlock from edx",
       author="Open FUN (France Universite Numérique)",
       author_email="fun.dev@fun-mooc.fr",


### PR DESCRIPTION
Add exrex which was forgotten in setup.py packaging. The package
was still working on our legaxy instances because exreg is installed
by requirements file. Which will not be the case in future.