### PR TITLE
allow display-capture and autoplay in the iframe 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.4.0] - 2022-04-13
+
 ### Added
 
 - Allow display-capture and autoplay in the iframe
@@ -98,7 +100,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 This is a first release candidate for production.
 
-[unreleased]: https://github.com/openfun/xblock-configurable-lti-consumer/compare/v1.3.0...master
+[unreleased]: https://github.com/openfun/xblock-configurable-lti-consumer/compare/v1.4.0...master
+[1.4.0]: https://github.com/openfun/xblock-configurable-lti-consumer/compare/v1.3.0...v1.4.0
 [1.3.0]: https://github.com/openfun/xblock-configurable-lti-consumer/compare/v1.2.4...v1.3.0
 [1.2.4]: https://github.com/openfun/xblock-configurable-lti-consumer/compare/v1.2.3...v1.2.4
 [1.2.3]: https://github.com/openfun/xblock-configurable-lti-consumer/compare/v1.2.2...v1.2.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- Allow display-capture and autoplay in the iframe
+
 ## [1.3.0] - 2019-10-17
 
 ### Changed

--- a/configurable_lti_consumer/templates/html/lti_iframe.html
+++ b/configurable_lti_consumer/templates/html/lti_iframe.html
@@ -7,5 +7,5 @@
     allowfullscreen="true"
     webkitallowfullscreen="true"
     mozallowfullscreen="true"
-    allow="microphone *; camera *; midi *; geolocation *; encrypted-media *"
+    allow="microphone *; camera *; midi *; geolocation *; encrypted-media *; display-capture; autoplay"
 ></iframe>

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,7 @@
 ;;
 [metadata]
 name = configurable_lti_consumer-xblock
-version = 1.3.0
+version = 1.4.0
 description = This Xblock adds configurability over the original lti_consumer XBlock from edx
 long_description = file: README.md
 long_description_content_type = text/markdown


### PR DESCRIPTION
## Purpose

We need to allow display-capture and autoplay security policy in the
iframe. Display-capture allow screen sharing and it's needed to use
jitsi in marsha and autoplay allow to play automatically a player also
in marsha.

## Proposal

- [x] allow display-capture and autoplay in the iframe 
- [x]  bump release to 1.4.0