### PR TITLE
🐛(core) allow display-capture and autoplay to all origins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- Allow display-capture and autoplay to all origins
+
 ## [1.4.0] - 2022-04-13
 
 ### Added

--- a/configurable_lti_consumer/templates/html/lti_iframe.html
+++ b/configurable_lti_consumer/templates/html/lti_iframe.html
@@ -7,5 +7,5 @@
     allowfullscreen="true"
     webkitallowfullscreen="true"
     mozallowfullscreen="true"
-    allow="microphone *; camera *; midi *; geolocation *; encrypted-media *; display-capture; autoplay"
+    allow="microphone *; camera *; midi *; geolocation *; encrypted-media *; display-capture *; autoplay *"
 ></iframe>


### PR DESCRIPTION
## Purpose

Previously we allowed in the iframe the security policy display-capture
and autoplay without specifying an allow origin list. Doing this only
`self` is accepted to iframe loading marsha are not allowed to
display-capture.

## Proposal

- [x]  allow display-capture and autoplay to all origins